### PR TITLE
refactor: streamline view layouts

### DIFF
--- a/views/chat_page.py
+++ b/views/chat_page.py
@@ -42,22 +42,34 @@ def show(defaults: dict):
             "Vanskelighetsgrad": st.session_state.get("difficulty", ""),
         },
     )
-    col1, col2, col3 = st.columns([1, 1, 2])
-    with col1:
-        if st.button("Til start", use_container_width=True):
-            st.session_state.page = "start"
-            st.rerun()
-    with col2:
-        if st.button("Nullstill", use_container_width=True):
-            reset_to_start(defaults)
-            st.rerun()
-    with col3:
+
+    with st.container():
+        col1, col2 = st.columns([1, 1])
+        with col1:
+            if st.button("Til start", use_container_width=True):
+                st.session_state.page = "start"
+                st.rerun()
+        with col2:
+            if st.button("Nullstill", use_container_width=True):
+                reset_to_start(defaults)
+                st.rerun()
+
+    st.divider()
+
+    with st.container():
         if st.session_state.get("ended"):
-            if st.button("Scenario avsluttet – Trykk her for feedback", type="primary", use_container_width=True):
+            if st.button(
+                "Scenario avsluttet – Trykk her for feedback",
+                type="primary",
+                use_container_width=True,
+            ):
                 st.session_state.page = "feedback"
                 st.rerun()
         else:
-            progress_turns(st.session_state.get("turns", 0), st.session_state.get("max_turns", MAX_TURNS))
+            progress_turns(
+                st.session_state.get("turns", 0),
+                st.session_state.get("max_turns", MAX_TURNS),
+            )
 
     # Bootstrap initial scene (use typing indicator only)
     if st.session_state.started and not st.session_state.history:

--- a/views/feedback_page.py
+++ b/views/feedback_page.py
@@ -40,17 +40,22 @@ def show(defaults: dict):
         )
 
     st.divider()
-    st.markdown("<div style='font-weight:800; font-size:1.1rem; color:#0f172a; margin: 0.3rem 0'>Hva vil du gjøre videre?</div>", unsafe_allow_html=True)
-    c1, c2, c3 = st.columns([1, 1, 1])
-    with c1:
-        if st.button("Til start", use_container_width=True):
-            reset_to_start(defaults)
-            st.rerun()
-    with c2:
+    st.markdown(
+        "<div style='font-weight:800; font-size:1.1rem; color:#0f172a; margin: 0.3rem 0'>Hva vil du gjøre videre?</div>",
+        unsafe_allow_html=True,
+    )
+
+    with st.container():
+        c1, c2 = st.columns([1, 1])
+        with c1:
+            if st.button("Til start", use_container_width=True):
+                reset_to_start(defaults)
+                st.rerun()
+        with c2:
+            if st.button("Se chat-logg", use_container_width=True):
+                st.session_state.page = "chat"
+                st.rerun()
+
         if st.button("Prøv på nytt (samme innstillinger)", use_container_width=True):
             restart_chat()
-            st.rerun()
-    with c3:
-        if st.button("Se chat-logg", use_container_width=True):
-            st.session_state.page = "chat"
             st.rerun()

--- a/views/start_page.py
+++ b/views/start_page.py
@@ -11,31 +11,35 @@ def show(defaults: dict):
     )
 
     with st.form("start-form", clear_on_submit=False):
-        c1, c2 = st.columns([1, 1])
-        with c1:
-            st.session_state.user_name = st.text_input(
-                "Ditt navn",
-                value=st.session_state.user_name,
-                placeholder="Skriv inn navnet ditt",
-            )
-        with c2:
-            # Difficulty control (keep select_slider but themed via CSS; label contrast improved)
-            st.session_state["difficulty"] = st.select_slider(
-                "Vanskelighetsgrad",
-                options=["Lett", "Medium", "Vanskelig"],
-                value=st.session_state.get("difficulty", "Medium"),
+        with st.container():
+            c1, c2 = st.columns([1, 1])
+            with c1:
+                st.session_state.user_name = st.text_input(
+                    "Ditt navn",
+                    value=st.session_state.user_name,
+                    placeholder="Skriv inn navnet ditt",
+                )
+            with c2:
+                # Difficulty control (keep select_slider but themed via CSS; label contrast improved)
+                st.session_state["difficulty"] = st.select_slider(
+                    "Vanskelighetsgrad",
+                    options=["Lett", "Medium", "Vanskelig"],
+                    value=st.session_state.get("difficulty", "Medium"),
+                )
+
+            st.markdown(
+                "<div class='callout' style='color:#0f172a; margin-top:6px'>Du kan endre innstillingene senere. Navnet brukes i dialogen.</div>",
+                unsafe_allow_html=True,
             )
 
-        st.markdown(
-            "<div class='callout' style='color:#0f172a; margin-top:6px'>Du kan endre innstillingene senere. Navnet brukes i dialogen.</div>",
-            unsafe_allow_html=True,
-        )
+        st.divider()
 
-        b1, b2 = st.columns([1, 1])
-        with b1:
-            start = st.form_submit_button("Start scenario", type="primary", use_container_width=True)
-        with b2:
-            reset = st.form_submit_button("Nullstill", use_container_width=True)
+        with st.container():
+            b1, b2 = st.columns([1, 1])
+            with b1:
+                start = st.form_submit_button("Start scenario", type="primary", use_container_width=True)
+            with b2:
+                reset = st.form_submit_button("Nullstill", use_container_width=True)
 
     if 'reset' in locals() and reset:
         reset_to_start(defaults)


### PR DESCRIPTION
## Summary
- use containers and dividers for grouped actions across views
- reduce button columns to 2 and unify spacing
- simplify feedback navigation for clarity

## Testing
- `streamlit run app.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b754731c64832e9f71ddecc81d8687