### PR TITLE
Add persona icons and legend to chat UI

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,18 +8,18 @@ MIN_STREAM_TIME_SEC = 0.8
 
 # UI theme constants (aligned to palette #0fa3b1, #b5e2fa, #f9f7f3, #eddea4, #f7a072)
 PERSONA_THEME = {
-    "Kunde": {"color": "#f7a072", "avatar": "😠"},
-    "Student": {"color": "#0fa3b1", "avatar": "🎓"},
-    "Kollega": {"color": "#eddea4", "avatar": "👩‍🍳"},
-    "Bystander": {"color": "#b5e2fa", "avatar": "👀"},
-    "Ditt svar": {"color": "#0fa3b1", "avatar": "🫵"},
-    "_you": {"color": "#0fa3b1", "avatar": "🧑‍🍳"},
-    "Scene": {"color": "#eddea4", "avatar": "🎬"},
-    "Forteller": {"color": "#eddea4", "avatar": "🎬"},
-    "Scenario-resultat": {"color": "#0fa3b1", "avatar": "✅"},
-    "Scenarioresultat": {"color": "#0fa3b1", "avatar": "✅"},
-    "Tilbakemelding": {"color": "#f7a072", "avatar": "💡"},
-    "_default": {"color": "#0fa3b1", "avatar": "🤖"},
+    "Kunde": {"color": "#f7a072", "avatar": "😠", "label": "Kunde"},
+    "Student": {"color": "#0fa3b1", "avatar": "🎓", "label": "Student"},
+    "Kollega": {"color": "#eddea4", "avatar": "👩‍🍳", "label": "Kollega"},
+    "Bystander": {"color": "#b5e2fa", "avatar": "👀", "label": "Forbipasserende"},
+    "Ditt svar": {"color": "#0fa3b1", "avatar": "🫵", "label": "Ditt svar"},
+    "_you": {"color": "#0fa3b1", "avatar": "🧑‍🍳", "label": "Deg"},
+    "Scene": {"color": "#eddea4", "avatar": "🎬", "label": "Scene"},
+    "Forteller": {"color": "#eddea4", "avatar": "🎬", "label": "Forteller"},
+    "Scenario-resultat": {"color": "#0fa3b1", "avatar": "✅", "label": "Scenario-resultat"},
+    "Scenarioresultat": {"color": "#0fa3b1", "avatar": "✅", "label": "Scenarioresultat"},
+    "Tilbakemelding": {"color": "#f7a072", "avatar": "💡", "label": "Tilbakemelding"},
+    "_default": {"color": "#0fa3b1", "avatar": "🤖", "label": "Agent"},
 }
 
 ROLE_TO_FALLBACK_NAME = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,8 @@
 import importlib
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 
 def test_config_constants_and_mappings():
@@ -9,9 +13,9 @@ def test_config_constants_and_mappings():
 
     assert isinstance(config.PERSONA_THEME, dict)
     assert "Kunde" in config.PERSONA_THEME
-    # Each theme entry has color and avatar
+    # Each theme entry has color, avatar and label
     for theme in config.PERSONA_THEME.values():
-        assert "color" in theme and "avatar" in theme
+        assert "color" in theme and "avatar" in theme and "label" in theme
 
     assert isinstance(config.ROLE_TO_FALLBACK_NAME, dict)
     for role in ["customer", "student", "employee", "bystander", "user", "system"]:

--- a/views/chat_page.py
+++ b/views/chat_page.py
@@ -5,8 +5,13 @@ import streamlit as st
 
 from config import CONTEXT_MESSAGES, MAX_TURNS
 from model_api import call_model
-from ui_components import render_history, render_turn_banner, page_header, progress_turns
-from config import PERSONA_THEME
+from ui_components import (
+    render_history,
+    render_turn_banner,
+    page_header,
+    progress_turns,
+    render_chat_message,
+)
 from state import reset_to_start
 
 
@@ -80,14 +85,7 @@ def show(defaults: dict):
             user_msg = {"name": st.session_state.user_name or "Ansatt", "role": "employee", "content": user_text}
             st.session_state.history.append(user_msg)
             # Immediate echo with same bubble style as history (no role label on self)
-            with st.chat_message("user", avatar=PERSONA_THEME["_you"]["avatar"]):
-                st.markdown(
-                    f"<div class='bubble bubble-right'>"
-                    f"<div class='bubble-header'>{user_msg['name']}</div>"
-                    f"<div class='bubble-content'>{user_msg['content']}</div>"
-                    f"</div>",
-                    unsafe_allow_html=True,
-                )
+            render_chat_message(user_msg, st.session_state.user_name or "")
 
             # Automatic end trigger: user types "end scenario" (or "avslutt scenario")
             if user_text.strip().lower() in ("end scenario", "avslutt scenario"):

--- a/views/start_page.py
+++ b/views/start_page.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 from state import reset_to_start, restart_chat
-from ui_components import page_header
+from ui_components import page_header, render_persona_legend
 
 
 def show(defaults: dict):
@@ -47,3 +47,5 @@ def show(defaults: dict):
             return
         restart_chat()
         st.rerun()
+
+    render_persona_legend()


### PR DESCRIPTION
## Summary
- add labels and emojis for each persona in configuration
- render chat messages with persona icons and provide legend on start page
- ensure user messages also use shared renderer for consistent icons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b754760c8c832eba3ac36711423c8f