### PR TITLE
feat: center feedback button

### DIFF
--- a/views/chat_page.py
+++ b/views/chat_page.py
@@ -42,22 +42,30 @@ def show(defaults: dict):
             "Vanskelighetsgrad": st.session_state.get("difficulty", ""),
         },
     )
-    col1, col2, col3 = st.columns([1, 1, 2])
-    with col1:
-        if st.button("Til start", use_container_width=True):
-            st.session_state.page = "start"
-            st.rerun()
-    with col2:
-        if st.button("Nullstill", use_container_width=True):
-            reset_to_start(defaults)
-            st.rerun()
-    with col3:
-        if st.session_state.get("ended"):
-            if st.button("Scenario avsluttet – Trykk her for feedback", type="primary", use_container_width=True):
+    if st.button("Til start", use_container_width=True):
+        st.session_state.page = "start"
+        st.rerun()
+
+    if st.button("Nullstill", use_container_width=True):
+        reset_to_start(defaults)
+        st.rerun()
+
+    if st.session_state.get("ended"):
+        with st.container():
+            st.success("Scenarioet er ferdig!")
+            if st.button(
+                "Gi tilbakemelding",
+                type="primary",
+                icon=":material/feedback:",
+                use_container_width=True,
+            ):
                 st.session_state.page = "feedback"
                 st.rerun()
-        else:
-            progress_turns(st.session_state.get("turns", 0), st.session_state.get("max_turns", MAX_TURNS))
+    else:
+        progress_turns(
+            st.session_state.get("turns", 0),
+            st.session_state.get("max_turns", MAX_TURNS),
+        )
 
     # Bootstrap initial scene (use typing indicator only)
     if st.session_state.started and not st.session_state.history:


### PR DESCRIPTION
## Summary
- replace column layout with full-width container for scenario completion
- highlight feedback CTA with primary styling, icon, and success message

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75476a8d0832ea2524a3d71bf8a55