### PR TITLE
fix: add agents dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 streamlit>=1.30
 pydantic>=2.0
 pytest>=7.0
+openai>=1.0.0
+agents @ git+https://github.com/openai/agents


### PR DESCRIPTION
## Summary
- add OpenAI `agents` and `openai` packages to requirements

## Testing
- `pytest -q`
- `streamlit run app.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b7dd7fe454832e9a45fbd8dfa08a32