### PR TITLE
fix: install agents from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.30
 pydantic>=2.0
 pytest>=7.0
+openai-agents>=0.2.10


### PR DESCRIPTION
## Summary
- install `openai-agents` from PyPI instead of cloning from GitHub

## Testing
- `pytest -q`
- `streamlit run app.py --server.headless true --server.fileWatcherType none`


------
https://chatgpt.com/codex/tasks/task_e_68b7dd7fe454832e9a45fbd8dfa08a32