### PR TITLE
refactor: support existing asyncio loops

### DIFF
--- a/async_utils.py
+++ b/async_utils.py
@@ -1,0 +1,37 @@
+import asyncio
+import threading
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+def run_async(coro: Coroutine[Any, Any, T]) -> T:
+    """Run *coro* regardless of existing event loop state.
+
+    If an event loop is already running, run the coroutine in a new loop.
+    Otherwise, use the current loop. This avoids ``asyncio.run`` which
+    fails when called from a running loop.
+    """
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    if loop.is_running():
+        result: dict[str, T] = {}
+
+        def _run() -> None:
+            inner_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(inner_loop)
+            try:
+                task = inner_loop.create_task(coro)
+                result["value"] = inner_loop.run_until_complete(task)
+            finally:
+                inner_loop.close()
+
+        thread = threading.Thread(target=_run)
+        thread.start()
+        thread.join()
+        return result["value"]
+    else:
+        return loop.run_until_complete(coro)

--- a/model_api.py
+++ b/model_api.py
@@ -1,12 +1,12 @@
 import json
 import time
-import asyncio
 from typing import List, Dict, Optional, Literal
 
 import streamlit as st
 from pydantic import BaseModel, Field
 
 from config import MIN_STREAM_TIME_SEC
+from async_utils import run_async
 
 # Agents framework
 from agents import Agent, Runner
@@ -139,7 +139,7 @@ def call_model(compiled_input: str, stream_placeholder: Optional[object] = None)
         result = await Runner.run(scenario_agent, compiled_input, context=ctx)
         return result.final_output
 
-    raw_out = asyncio.run(_run())
+    raw_out = run_async(_run())
 
     # Robustly coerce the agent output into ScenarioOutput
     def _coerce_output(val) -> ScenarioOutput:
@@ -245,7 +245,7 @@ def call_model(compiled_input: str, stream_placeholder: Optional[object] = None)
                     pass
             return EndDecision(should_end=False)
 
-        decision: EndDecision = asyncio.run(_monitor())
+        decision: EndDecision = run_async(_monitor())
         if decision and decision.should_end:
             st.session_state.last_meta = {
                 "oppdrag": (out.oppdrag.beskrivelse if out.oppdrag else None),

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from async_utils import run_async
+
+
+async def sample_coro():
+    await asyncio.sleep(0.01)
+    return "done"
+
+
+def test_run_async_without_running_loop():
+    assert run_async(sample_coro()) == "done"
+
+
+def test_run_async_with_existing_loop():
+    results = []
+
+    async def runner():
+        results.append(run_async(sample_coro()))
+
+    asyncio.run(runner())
+    assert results == ["done"]


### PR DESCRIPTION
## Summary
- add `run_async` helper to safely execute coroutines with or without a running event loop
- use `run_async` instead of `asyncio.run` in `model_api`
- test `run_async` for scenarios with and without an existing loop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80805f028832eb3739c60e15054a1