### PR TITLE
fix: allow realistic scenario inputs

### DIFF
--- a/model_api.py
+++ b/model_api.py
@@ -44,8 +44,10 @@ class ScenarioOutput(BaseModel):
 
 
 # Guardrail to ensure scenario inputs stay on topic
-def check_training_context(context, agent, compiled_input: str | List[Dict]) -> GuardrailFunctionOutput:
-    """Validate that the input contains scenario keywords and no disallowed content."""
+def check_training_context(
+    context, agent, compiled_input: str | List[Dict]
+) -> GuardrailFunctionOutput:
+    """Validate that the input contains expected scenario markers and no disallowed content."""
 
     if isinstance(compiled_input, list):
         text = " ".join(str(item) for item in compiled_input)
@@ -53,10 +55,17 @@ def check_training_context(context, agent, compiled_input: str | List[Dict]) -> 
         text = str(compiled_input)
 
     lowered = text.lower()
-    has_keyword = "scenario" in lowered
+    allowed_markers = [
+        "scenario",
+        "bruker",
+        "historikk",
+        "runde",
+        "vanskelighetsgrad",
+    ]
+    has_marker = any(marker in lowered for marker in allowed_markers)
     has_disallowed = any(bad in lowered for bad in ["forbidden", "disallowed"])
 
-    if has_disallowed or not has_keyword:
+    if has_disallowed or not has_marker:
         return GuardrailFunctionOutput(
             output_info="Input failed training context check.",
             tripwire_triggered=True,

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -57,7 +57,11 @@ async def _run_guardrail(text: str) -> None:
 
 
 def test_check_training_context_allows_valid_input():
-    asyncio.run(_run_guardrail("scenario: valid"))
+    asyncio.run(
+        _run_guardrail(
+            "Historikk: [] Bruker: Ola | Runde: 1/6 | Vanskelighetsgrad: Lett"
+        )
+    )
 
 
 def test_check_training_context_blocks_invalid_input():


### PR DESCRIPTION
## Summary
- allow guardrail to accept prompts generated by the UI by checking for Bruker, Historikk, Runde and Vanskelighetsgrad markers
- update guardrail test with realistic prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80ef982cc832eb2dfe9eb2cb3e61a