### PR TITLE
chore: add streamlit extras and elements dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ streamlit>=1.30
 pydantic>=2.0
 pytest>=7.0
 openai-agents>=0.2.10
+streamlit-extras==0.7.7
+streamlit-elements==0.1.0


### PR DESCRIPTION
## Summary
- add `streamlit-extras` and `streamlit-elements` to requirements

## Testing
- `.venv/bin/pip install -r requirements.txt`
- `.venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b812291294832e853292868184f50c