### PR TITLE
fix: parse code-fenced scenario output

### DIFF
--- a/model_api.py
+++ b/model_api.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from typing import List, Dict, Optional, Literal
 
@@ -164,14 +165,17 @@ def coerce_scenario_output(val) -> ScenarioOutput:
         if isinstance(val, dict):
             return ScenarioOutput(**val)
         if isinstance(val, str):
+            cleaned = val.strip()
+            cleaned = re.sub(r"^```\w*\n|```$", "", cleaned)
+            cleaned = cleaned.strip().strip("`")
             data = None
             try:
-                data = json.loads(val)
+                data = json.loads(cleaned)
             except Exception:
                 try:
                     import ast
 
-                    data = ast.literal_eval(val)
+                    data = ast.literal_eval(cleaned)
                 except Exception:
                     data = None
             if isinstance(data, dict):

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -36,6 +36,21 @@ def test_coerce_output_from_json_string():
     assert out.meldinger[0].content == "hei"
 
 
+def test_coerce_output_from_code_fenced_json():
+    st.session_state.clear()
+    data = {
+        "meldinger": [
+            {"name": "Scene", "role": "system", "content": "hei"}
+        ]
+    }
+    json_str = json.dumps(data)
+    fenced = f"```json\n{json_str}\n```"
+    out = coerce_scenario_output(fenced)
+    assert isinstance(out, ScenarioOutput)
+    assert len(out.meldinger) == 1
+    assert out.meldinger[0].content == "hei"
+
+
 def test_coerce_output_fallback_plain_text_initial():
     st.session_state.clear()
     out = coerce_scenario_output("uventet")


### PR DESCRIPTION
## Summary
- strip Markdown code fences from string outputs before parsing into ScenarioOutput
- add coverage for code-fenced JSON strings in coerce_scenario_output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b815d73130832eb598b090089fe102