### PR TITLE
feat: add stylable UI helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import streamlit as st
 from agents import set_default_openai_key
 
-from ui_components import inject_css
 from views.start_page import show as show_start
 from views.chat_page import show as show_chat
 from views.feedback_page import show as show_feedback
@@ -15,7 +14,6 @@ st.set_page_config(
     layout="centered",
     initial_sidebar_state="collapsed",
 )
-inject_css()
 
 
 # Initialize session state via centralized defaults

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -1,0 +1,66 @@
+import ui_components
+
+
+class Dummy:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_styled_container_wraps_extras(monkeypatch):
+    called = {}
+
+    def fake_sc(key, css_styles):
+        called["key"] = key
+        called["css"] = css_styles
+        return Dummy()
+
+    monkeypatch.setattr(ui_components, "stylable_container", fake_sc)
+    container = ui_components.styled_container("k", "css")
+    assert called == {"key": "k", "css": "css"}
+    assert isinstance(container, Dummy)
+
+
+def test_chip_uses_styled_container(monkeypatch):
+    sc_called = {}
+
+    class Dummy:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def fake_sc(key, css):
+        sc_called["key"] = key
+        sc_called["css"] = css
+        return Dummy()
+
+    markdown_called = {}
+
+    def fake_markdown(text):
+        markdown_called["text"] = text
+
+    monkeypatch.setattr(ui_components, "styled_container", fake_sc)
+    monkeypatch.setattr(ui_components.st, "markdown", fake_markdown)
+
+    ui_components.chip("A", "1")
+
+    assert sc_called["key"].startswith("chip-A")
+    assert "A: **1**" == markdown_called["text"]
+
+
+def test_external_badge_calls_badge(monkeypatch):
+    called = {}
+
+    def fake_badge(kind, name=None, url=None):
+        called.update({"kind": kind, "name": name, "url": url})
+
+    monkeypatch.setattr(ui_components, "_badge", fake_badge)
+
+    ui_components.external_badge("github", name="repo")
+
+    assert called == {"kind": "github", "name": "repo", "url": None}
+

--- a/views/feedback_page.py
+++ b/views/feedback_page.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from state import reset_to_start, restart_chat
-from ui_components import page_header
+from ui_components import page_header, chip
 
 
 def show(defaults: dict):
@@ -9,11 +9,8 @@ def show(defaults: dict):
     turns = st.session_state.get("turns", 0)
     diff = st.session_state.get("difficulty", "")
 
-    st.markdown(
-        f"<div class='chip chip-primary' style='margin-right:8px;'>Runder brukt: <b>{turns}</b></div>"
-        f"<div class='chip chip-muted'>Vanskelighetsgrad: <b>{diff}</b></div>",
-        unsafe_allow_html=True,
-    )
+    chip("Runder brukt", str(turns))
+    chip("Vanskelighetsgrad", str(diff))
 
     result = meta.get("scenarioresultat")
     feedback = meta.get("tilbakemelding")
@@ -26,10 +23,7 @@ def show(defaults: dict):
         st.warning(f"Tilbakemelding\n\n{feedback.get('content')}")
 
     st.divider()
-    st.markdown(
-        "<div style='font-weight:800; font-size:1.1rem; color:#0f172a; margin: 0.3rem 0'>Hva vil du gjøre videre?</div>",
-        unsafe_allow_html=True,
-    )
+    st.subheader("Hva vil du gjøre videre?")
 
     with st.container():
         c1, c2 = st.columns([1, 1])


### PR DESCRIPTION
## Summary
- centralize common UI helpers using streamlit-extras (stylable containers and badges)
- swap HTML chips for helper utilities in feedback page
- add tests covering new UI utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b815faa78c832e84c61d7683349b87