### PR TITLE
refactor: drop streamlit-extras dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ streamlit>=1.30
 pydantic>=2.0
 pytest>=7.0
 openai-agents>=0.2.10
-streamlit-extras==0.7.7

--- a/tests/test_ui_components.py
+++ b/tests/test_ui_components.py
@@ -2,6 +2,9 @@ import ui_components
 
 
 class Dummy:
+    def markdown(self, text, unsafe_allow_html=False):
+        self.calls.append((text, unsafe_allow_html))
+
     def __enter__(self):
         return self
 
@@ -9,58 +12,46 @@ class Dummy:
         pass
 
 
-def test_styled_container_wraps_extras(monkeypatch):
-    called = {}
+def test_styled_container_injects_style(monkeypatch):
+    dummy = Dummy()
+    dummy.calls = []
 
-    def fake_sc(key, css_styles):
-        called["key"] = key
-        called["css"] = css_styles
-        return Dummy()
+    monkeypatch.setattr(ui_components.st, "container", lambda: dummy)
 
-    monkeypatch.setattr(ui_components, "stylable_container", fake_sc)
-    container = ui_components.styled_container("k", "css")
-    assert called == {"key": "k", "css": "css"}
-    assert isinstance(container, Dummy)
+    with ui_components.styled_container("k", "{color:red;}"):
+        pass
+
+    assert ("<div style=\"color:red;\">", True) in dummy.calls
+    assert ("</div>", True) in dummy.calls
 
 
-def test_chip_uses_styled_container(monkeypatch):
-    sc_called = {}
+def test_chip_renders_span(monkeypatch):
+    captured = {}
 
-    class Dummy:
-        def __enter__(self):
-            return self
+    def fake_markdown(text, unsafe_allow_html=False):
+        captured["text"] = text
+        captured["unsafe"] = unsafe_allow_html
 
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-    def fake_sc(key, css):
-        sc_called["key"] = key
-        sc_called["css"] = css
-        return Dummy()
-
-    markdown_called = {}
-
-    def fake_markdown(text):
-        markdown_called["text"] = text
-
-    monkeypatch.setattr(ui_components, "styled_container", fake_sc)
     monkeypatch.setattr(ui_components.st, "markdown", fake_markdown)
 
     ui_components.chip("A", "1")
 
-    assert sc_called["key"].startswith("chip-A")
-    assert "A: **1**" == markdown_called["text"]
+    assert "A" in captured["text"] and "1" in captured["text"]
+    assert captured["unsafe"]
 
 
-def test_external_badge_calls_badge(monkeypatch):
-    called = {}
+def test_external_badge_renders_link(monkeypatch):
+    captured = {}
 
-    def fake_badge(kind, name=None, url=None):
-        called.update({"kind": kind, "name": name, "url": url})
+    def fake_markdown(text, unsafe_allow_html=False):
+        captured["text"] = text
+        captured["unsafe"] = unsafe_allow_html
 
-    monkeypatch.setattr(ui_components, "_badge", fake_badge)
+    monkeypatch.setattr(ui_components.st, "markdown", fake_markdown)
 
-    ui_components.external_badge("github", name="repo")
+    ui_components.external_badge("github", url="https://example.com")
 
-    assert called == {"kind": "github", "name": "repo", "url": None}
+    assert "github" in captured["text"]
+    assert "https://example.com" in captured["text"]
+    assert captured["unsafe"]
 

--- a/views/start_page.py
+++ b/views/start_page.py
@@ -1,9 +1,7 @@
 import streamlit as st
 
 from state import reset_to_start, restart_chat
-from ui_components import page_header
-from streamlit_extras.stylable_container import stylable_container
-from streamlit_extras.badges import badge
+from ui_components import page_header, styled_container, external_badge
 
 BLOCK_STYLE = """
     {
@@ -20,10 +18,10 @@ def show(defaults: dict):
         "Kriseøvelse – Sit Kafe",
         "Tren på å håndtere krevende kundedialoger i et trygt miljø.",
     )
-    badge("streamlit", url="https://streamlit.io")
+    external_badge("streamlit", url="https://streamlit.io")
 
     with st.form("start-form", clear_on_submit=False):
-        with stylable_container(key="name_difficulty", css_styles=BLOCK_STYLE):
+        with styled_container(key="name_difficulty", css=BLOCK_STYLE):
             c1, c2 = st.columns([1, 1])
             with c1:
                 st.session_state.user_name = st.text_input(
@@ -46,7 +44,7 @@ def show(defaults: dict):
             )
 
         # Optional: allow users to provide their own OpenAI API key
-        with stylable_container(key="api_key_block", css_styles=BLOCK_STYLE):
+        with styled_container(key="api_key_block", css=BLOCK_STYLE):
             st.session_state.api_key = st.text_input(
                 "OpenAI API-nøkkel (valgfritt)",
                 value=st.session_state.get("api_key", ""),


### PR DESCRIPTION
## Summary
- remove streamlit-extras from requirements
- replace stylable_container and badge utilities with native Streamlit HTML
- update start page and UI helpers to use new styling helpers
- adjust tests for new UI utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8279a8bf0832e94c0a48600bcdfde